### PR TITLE
Added debug, clone, copy traits

### DIFF
--- a/src/composition.rs
+++ b/src/composition.rs
@@ -188,8 +188,6 @@ pub enum CompositionError {
 
 #[cfg(test)]
 mod tests {
-    use std::default;
-
     use super::*;
 
     #[test]
@@ -260,7 +258,7 @@ mod tests {
         assert_eq!(gas_comp_clone.argon, 0.5);
     }
 
-        #[test]
+    #[test]
     fn copy_gas_comp() {
         let gas_comp = Composition {
             argon: 50.0,

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -20,7 +20,7 @@
 /// assert!((air.sum() - 1.0).abs() < 1.0e-10);
 /// ```
 #[repr(C)]
-#[derive(Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Composition {
     /// Methane CH<sub>4</sub>
     pub methane: f64,

--- a/src/composition.rs
+++ b/src/composition.rs
@@ -20,7 +20,7 @@
 /// assert!((air.sum() - 1.0).abs() < 1.0e-10);
 /// ```
 #[repr(C)]
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Default, Clone, Copy)]
 pub struct Composition {
     /// Methane CH<sub>4</sub>
     pub methane: f64,
@@ -188,6 +188,8 @@ pub enum CompositionError {
 
 #[cfg(test)]
 mod tests {
+    use std::default;
+
     use super::*;
 
     #[test]
@@ -242,5 +244,31 @@ mod tests {
         };
 
         assert_eq!(comp.normalize(), Err(CompositionError::Empty));
+    }
+
+    #[test]
+    fn clone_gas_comp() {
+        let mut gas_comp = Composition {
+            argon: 50.0,
+            methane: 50.0,
+            ..Default::default()
+        };
+        let mut gas_comp_clone = gas_comp.clone();
+
+        gas_comp.argon = 0.0;
+        gas_comp_clone.normalize().unwrap();
+        assert_eq!(gas_comp_clone.argon, 0.5);
+    }
+
+        #[test]
+    fn copy_gas_comp() {
+        let gas_comp = Composition {
+            argon: 50.0,
+            methane: 50.0,
+            ..Default::default()
+        };
+        let mut gas_comp_clone = gas_comp;
+        gas_comp_clone.normalize().unwrap();
+        assert_eq!(gas_comp_clone.argon, 0.5);
     }
 }

--- a/src/detail.rs
+++ b/src/detail.rs
@@ -654,6 +654,7 @@ const TH0I: [[f64; 7]; MAXFLDS] = [
 /// assert!((12.807_924_036_488_01 - aga8_test.d).abs() < 1.0e-10);
 /// ```
 
+#[derive(Debug, Clone, Copy)]
 pub struct Detail {
     // Calculated in the Pressure subroutine,
     // but not included as an argument since it

--- a/src/detail.rs
+++ b/src/detail.rs
@@ -1408,6 +1408,7 @@ impl Detail {
 }
 
 
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -1434,6 +1435,7 @@ mod tests {
         assert!((detail_clone.d - expected_density).abs() < 0.001);
     }
 
+    #[test]
     fn copy_detail() {
         let mut detail = Detail::new();
         let mut gas_comp = Composition::default();

--- a/src/detail.rs
+++ b/src/detail.rs
@@ -654,7 +654,7 @@ const TH0I: [[f64; 7]; MAXFLDS] = [
 /// assert!((12.807_924_036_488_01 - aga8_test.d).abs() < 1.0e-10);
 /// ```
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct Detail {
     // Calculated in the Pressure subroutine,
     // but not included as an argument since it
@@ -1404,5 +1404,55 @@ impl Detail {
         self.w = self.w.sqrt();
         self.kappa = self.w * self.w * mm / (rt * 1000.0 * self.z);
         self.d2p_dtd = 0.0;
+    }
+}
+
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clone_detail() {
+        let mut detail = Detail::new();
+        let mut gas_comp = Composition::default();
+        gas_comp.nitrogen = 1.0;
+
+        _ = detail.set_composition(&gas_comp);
+        detail.t = 273.15;
+        detail.p = 200.0;
+        _ = detail.density();
+        detail.properties();
+
+        let mut detail_clone = detail.clone();
+        detail_clone.p = 100.0;
+        _ = detail_clone.density();
+        detail_clone.properties();
+        assert!((detail_clone.t - 273.15).abs() < 0.000001);
+        assert!((detail_clone.p - 100.0).abs() <  0.000001);
+
+        let expected_density = 0.0446; // mol/l STP
+        assert!((detail_clone.d - expected_density).abs() < 0.001);
+    }
+
+    fn copy_detail() {
+        let mut detail = Detail::new();
+        let mut gas_comp = Composition::default();
+        gas_comp.nitrogen = 1.0;
+
+        _ = detail.set_composition(&gas_comp);
+        detail.t = 273.15;
+        detail.p = 200.0;
+        _ = detail.density();
+        detail.properties();
+
+        let mut detail_copy = detail;
+        detail_copy.p = 100.0;
+        _ = detail_copy.density();
+        detail_copy.properties();
+        assert!((detail_copy.t - 273.15).abs() < 0.000001);
+        assert!((detail_copy.p - 100.0).abs() <  0.000001);
+
+        let expected_density = 0.0446; // mol/l STP
+        assert!((detail_copy.d - expected_density).abs() < 0.001);
     }
 }

--- a/src/gerg2008.rs
+++ b/src/gerg2008.rs
@@ -2350,7 +2350,7 @@ const GTIJ: [[f64; MAXFLDS + 1]; MAXFLDS + 1] = [
 /// // Compressibility factor
 /// assert!((1.175 - gerg_test.z).abs() < 1.0e-3);
 /// ```
-#[derive(Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct Gerg2008 {
     /// Temperature in K
     pub t: f64,

--- a/src/gerg2008.rs
+++ b/src/gerg2008.rs
@@ -4711,6 +4711,7 @@ impl Gerg2008 {
 }
 
 
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -4737,6 +4738,7 @@ mod tests {
         assert!((detail_clone.d - expected_density).abs() < 0.001);
     }
 
+    #[test]
     fn copy_gerg() {
         let mut detail = Gerg2008::new();
         let mut gas_comp = Composition::default();

--- a/src/gerg2008.rs
+++ b/src/gerg2008.rs
@@ -4715,7 +4715,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn clone_detail() {
+    fn clone_gerg() {
         let mut detail = Gerg2008::new();
         let mut gas_comp = Composition::default();
         gas_comp.nitrogen = 1.0;
@@ -4737,7 +4737,7 @@ mod tests {
         assert!((detail_clone.d - expected_density).abs() < 0.001);
     }
 
-    fn copy_detail() {
+    fn copy_gerg() {
         let mut detail = Gerg2008::new();
         let mut gas_comp = Composition::default();
         gas_comp.nitrogen = 1.0;

--- a/src/gerg2008.rs
+++ b/src/gerg2008.rs
@@ -2350,7 +2350,7 @@ const GTIJ: [[f64; MAXFLDS + 1]; MAXFLDS + 1] = [
 /// // Compressibility factor
 /// assert!((1.175 - gerg_test.z).abs() < 1.0e-3);
 /// ```
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Default, Clone, Copy)]
 pub struct Gerg2008 {
     /// Temperature in K
     pub t: f64,
@@ -4707,5 +4707,55 @@ impl Gerg2008 {
             dcx = 1.0 / vcx;
         }
         (dcx, tcx)
+    }
+}
+
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clone_detail() {
+        let mut detail = Gerg2008::new();
+        let mut gas_comp = Composition::default();
+        gas_comp.nitrogen = 1.0;
+
+        _ = detail.set_composition(&gas_comp);
+        detail.t = 273.15;
+        detail.p = 200.0;
+        _ = detail.density(0);
+        detail.properties();
+
+        let mut detail_clone = detail.clone();
+        detail_clone.p = 100.0;
+        _ = detail_clone.density(0);
+        detail_clone.properties();
+        assert!((detail_clone.t - 273.15).abs() < 0.000001);
+        assert!((detail_clone.p - 100.0).abs() <  0.000001);
+
+        let expected_density = 0.0446; // mol/l STP
+        assert!((detail_clone.d - expected_density).abs() < 0.001);
+    }
+
+    fn copy_detail() {
+        let mut detail = Gerg2008::new();
+        let mut gas_comp = Composition::default();
+        gas_comp.nitrogen = 1.0;
+
+        _ = detail.set_composition(&gas_comp);
+        detail.t = 273.15;
+        detail.p = 200.0;
+        _ = detail.density(0);
+        detail.properties();
+
+        let mut detail_copy = detail;
+        detail_copy.p = 100.0;
+        _ = detail_copy.density(0);
+        detail_copy.properties();
+        assert!((detail_copy.t - 273.15).abs() < 0.000001);
+        assert!((detail_copy.p - 100.0).abs() <  0.000001);
+
+        let expected_density = 0.0446; // mol/l STP
+        assert!((detail_copy.d - expected_density).abs() < 0.001);
     }
 }


### PR DESCRIPTION
Adding debug, clone, and copy traits to Detail, Gerg2008, and Composition can make the code a little easier for end users working to implement this into other software.  Being able to clone compositions and states is very useful, no need to do work around when implementing in other code.

Testing after changes:
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
